### PR TITLE
Improve syntax highlighting and indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ Interactive functions available:
 - `mos-build`: Build the program (based on mos.toml settings)
 - `mos-run-all-tests`: Run all the unit tests in the project (depends on presense of mos.toml)
 - `mos-run-program` / `mos-debug-program`: Run or debug the program.
+
+
+By default mos-mode will format the buffer when saving. You can toggle this behavior with `mos-format-on-save` (e.g, set it to nil to not format on save)
+

--- a/mos-mode.el
+++ b/mos-mode.el
@@ -49,6 +49,10 @@
 ;; font lock to get proper syntax highlighting
 (defconst mos-font-lock-keywords
   (list
+   ;; labels
+   (cons "[a-zA-Z0-9_]+\\:" 'font-lock-function-name-face)
+   ;; macro invocation
+   (cons "[a-zA-Z0-9_]+(.*)" 'font-lock-function-name-face)
    ;; mnemonics/asm opcodes
    (cons "[ ]+\\(adc\\|and\\|asl\\|bcc\\|bcs\\|beq\\|bit\\|bmi\\|bne\\|bpl\\|brk\\|bvc\\|bvs\\|clc\\|cld\\|cli\\|clv\\|cmp\\|cpx\\|cpy\\|dec\\|dex\\|dey\\|eor\\|inc\\|inx\\|iny\\|jmp\\|jsr\\|lda\\|ldx\\|ldy\\|lsr\\|nop\\|ora\\|pha\\|php\\|pla\\|plp\\|rol\\|ror\\|rti\\|rts\\|sbc\\|sec\\|sed\\|sei\\|sta\\|stx\\|sty\\|tax\\|tay\\|tsx\\|txa\\|txs\\|tya\\)"
          'font-lock-keyword-face)
@@ -56,8 +60,6 @@
    (cons (regexp-opt '(".const" ".var" ".byte" ".word" ".dword" ".macro" ".define" ".segment" ".loop" ".align" ".if" "else" "as" ".import" "from" ".text" "ascii" "petscii" "petscreen" ".file" ".assert" ".trace" ".test")
                      t)
          'font-lock-builtin-face)
-   ;; labels
-   (cons "\\w+\\:" 'font-lock-function-name-face)
    ;; hexadecimals
    (cons "#?\\$[0-9A-Fa-f]+" 'font-lock-constant-face)
    ;; binary numbers

--- a/mos-mode.el
+++ b/mos-mode.el
@@ -79,7 +79,7 @@
              (looking-at "^[[:blank:]]*$"))
     (mos--jump-to-prev-non-empty-line)))
 
-(defconst mos--regex-label-pattern "[[:blank:]]*[a-zA-Z0-9]+:"
+(defconst mos--regex-label-pattern "[[:blank:]]*[a-zA-Z0-9_]+:"
   "Pattern to check if something is an assembly label.")
 
 (defun mos-indent-line ()

--- a/mos-mode.el
+++ b/mos-mode.el
@@ -41,10 +41,33 @@
   :group 'mos-mode
   :type 'string)
 
+;; font lock to get proper syntax highlighting
+(defconst mos-font-lock-keywords
+  (list
+   ;; mnemonics/asm opcodes
+   (cons "[ ]+\\(adc\\|and\\|asl\\|bcc\\|bcs\\|beq\\|bit\\|bmi\\|bne\\|bpl\\|brk\\|bvc\\|bvs\\|clc\\|cld\\|cli\\|clv\\|cmp\\|cpx\\|cpy\\|dec\\|dex\\|dey\\|eor\\|inc\\|inx\\|iny\\|jmp\\|jsr\\|lda\\|ldx\\|ldy\\|lsr\\|nop\\|ora\\|pha\\|php\\|pla\\|plp\\|rol\\|ror\\|rti\\|rts\\|sbc\\|sec\\|sed\\|sei\\|sta\\|stx\\|sty\\|tax\\|tay\\|tsx\\|txa\\|txs\\|tya\\)"
+         'font-lock-keyword-face)
+   ;; mos builtins
+   (cons (regexp-opt '(".const" ".var" ".byte" ".word" ".dword" ".macro" ".define" ".segment" ".loop" ".align" ".if" "else" "as" ".import" "from" ".text" "ascii" "petscii" "petscreen" ".file" ".assert" ".trace" ".test")
+                     t)
+         'font-lock-builtin-face)
+   ;; labels
+   (cons "\\w+\\:" 'font-lock-function-name-face)
+   ;; hexadecimals
+   (cons "#?\\$[0-9A-Fa-f]+" 'font-lock-constant-face)
+   ;; binary numbers
+   (cons "#?\\%[0-1]+" 'font-lock-constant-face)
+   ;; decimals
+   (cons "#?[0-9]+" 'font-lock-constant-face)
+   ;; comments
+   (cons "/\\*.*\\*/" 'font-lock-comment-face)
+   (cons "//.*$" 'font-lock-comment-face))
+  "Highlighting rules for MOS, mostly 6502 assembly syntax with some special built-ins on top")
 ;; simple major mode based on assembly mode that can be activated
 (define-derived-mode mos-mode
-  asm-mode "MOS mode"
-  "Major mode for use with the MOS toolkit for 6502 processors.")
+  fundamental-mode "MOS mode"
+  "Major mode for use with the MOS toolkit for 6502 processors."
+  (setq font-lock-defaults '(mos-font-lock-keywords nil t)))
 
 (add-to-list 'lsp-language-id-configuration '(mos-mode . "mos"))
 (add-to-list 'mos-mode-hook #'lsp)


### PR DESCRIPTION
Fixes #4 


Syntax and indentation now work in a way that is more similar to what MOS expect. That means you will experience less inconsistency with how MOS formats your code. Also added a format on save action that can be tweaked with `mos-format-on-save` (e.g, set it to nil to not format on save). 


The syntax and indentation might not be perfect, but it is at least an improvement. In the future we might instead get formatting settings directly from MOS and use them directly (requires custom protocol extension probably). 